### PR TITLE
Fix floating label

### DIFF
--- a/app/assets/javascripts/sephora_style_guide/floating_label.js
+++ b/app/assets/javascripts/sephora_style_guide/floating_label.js
@@ -5,10 +5,16 @@ $(document).ready(function(){
         CHZN_SELECT_CLASS = '.chzn-select';
 
     $(document).on('focus blur', INPUT_CLASS, function (e) {
+      var valLength = this.value.length;
+      var placeholder = this.getAttribute('placeholder');
+
       $(this).parents(PARENT_CLASS)
           .toggleClass('focus', e.type === 'focus' ||  e.type === 'focusin')
-          .toggleClass('filled', this.value.length > 0)
-          .toggleClass('focused', (e.type === 'focus'||  e.type === 'focusin' || this.value.length > 0 || (this.value.length === 0 && typeof this.getAttribute('placeholder') === 'string')));
+          .toggleClass('filled', valLength > 0)
+          .toggleClass('focused', (e.type === 'focus'||
+            e.type === 'focusin' ||
+            valLength > 0 ||
+            (valLength === 0 && typeof placeholder === 'string' && placeholder.length > 0)));
     });
 
     $(INPUT_CLASS).trigger('blur');


### PR DESCRIPTION
Description:
This adds a condition to apply `focused` class on an input field. The condition checks whether the length of the placeholder is greater than 0. If so, it applies the `focused` class.

The motivation for this is that if an input field has an empty string as a placeholder then the `focused` class should not be applied. Although usually a placeholder will never be empty, this would be required in some cases where a default placeholder imposed by a library and we need to override it with an empty string. 

The issue was detected in https://sephora-asia.atlassian.net/browse/US-903

Before:
![image](https://user-images.githubusercontent.com/17158390/63242351-bcbcde80-c274-11e9-9d4d-a175d8766e0c.png)

After:
![image](https://user-images.githubusercontent.com/17158390/63243076-17efd080-c277-11e9-822a-078166928686.png)
