### PR TITLE
[KRO-78] Fix unintended scrollbar on modals in mobile devices

### DIFF
--- a/app/assets/stylesheets/sephora_style_guide/components/_modal.scss
+++ b/app/assets/stylesheets/sephora_style_guide/components/_modal.scss
@@ -42,7 +42,7 @@
 
 // Shell div to position the modal with bottom padding
 .modal-dialog {
-  min-height: calc(100vh - 10px);
+  min-height: calc(100vh - 20px);
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
## Description

`modal-dialog` has a margin of 10px, giving it a 10px margin on top &
bottom. However, min-height is set to `calc(100vh - 10px)`. This causes
a scrollbar to appear even when there is no content overflow.

Considering the vertical margins, min-height should be subtracted by
20px from viewport height. This commit thus changes the
min-height to `calc(100vh - 20px)`

## Links
https://sephora-asia.atlassian.net/browse/KRO-78