### PR TITLE
Add bright red to colors

### DIFF
--- a/app/assets/stylesheets/sephora_style_guide/variables/_color.scss
+++ b/app/assets/stylesheets/sephora_style_guide/variables/_color.scss
@@ -2,6 +2,7 @@ $brand-primary: #d50032;
 $brand-success: #3a773a;
 $brand-info:    #c000c4;
 $brand-error:   #e00;
+$red-light:     #ff4057;
 
 $white:         #fff;
 $grey-light:    #f1f1f1;


### PR DESCRIPTION
Add `#ff4057` to colors to be used in the new PDP layout:

Desktop: https://projects.invisionapp.com/d/main/#/console/18251784/378957488/inspect
mWeb: https://projects.invisionapp.com/d/main/#/console/18251039/378946865/inspect

![image](https://user-images.githubusercontent.com/5366804/64845878-e1fcfc80-d628-11e9-8c0d-e4507752f039.png)
