### PR TITLE
[MS-1014] Add custom font family for vi

### DIFF
--- a/app/assets/stylesheets/sephora_style_guide/_reset.scss
+++ b/app/assets/stylesheets/sephora_style_guide/_reset.scss
@@ -28,6 +28,10 @@ html {
     font-size: $font-size-root;
     line-height: $line-height-root;
   }
+
+  :lang(vi) { 
+    font-family: CenturyGothic, Helvetica, Arial; 
+  }
 }
 
 body {

--- a/app/assets/stylesheets/sephora_style_guide/mixins/_typography.scss
+++ b/app/assets/stylesheets/sephora_style_guide/mixins/_typography.scss
@@ -3,6 +3,10 @@
   font-style: normal;
   font-weight: 400;
   letter-spacing: normal;
+
+  :lang(vi) { 
+    font-family: CenturyGothic, Helvetica, Arial; 
+  }
 }
 
 @mixin font-sephora-serif-italic {
@@ -10,6 +14,10 @@
   font-style: italic;
   font-weight: 400;
   letter-spacing: normal;
+
+  :lang(vi) { 
+    font-family: CenturyGothic, Helvetica, Arial; 
+  }
 }
 
 @mixin font-sephora-sans {
@@ -17,6 +25,10 @@
   font-style: normal;
   font-weight: 400;
   letter-spacing: 0.3px;
+
+  :lang(vi) { 
+    font-family: CenturyGothic, Helvetica, Arial; 
+  }
 }
 
 @mixin font-weight-light {

--- a/app/assets/stylesheets/sephora_style_guide/mixins/_typography.scss
+++ b/app/assets/stylesheets/sephora_style_guide/mixins/_typography.scss
@@ -5,7 +5,7 @@
   letter-spacing: normal;
 
   :lang(vi) { 
-    font-family: CenturyGothic, Helvetica, Arial; 
+    font-family: Palatino, Georgia, Times; 
   }
 }
 
@@ -16,7 +16,7 @@
   letter-spacing: normal;
 
   :lang(vi) { 
-    font-family: CenturyGothic, Helvetica, Arial; 
+    font-family: Palatino, Georgia, Times; 
   }
 }
 


### PR DESCRIPTION
Sephora Sans does not support characters in the Vietnamese language.

When Sephora Sans is loaded in the Vietnam site, when Vietnamese language is selected, the fonts does appear inconsistent as some fonts will be using Sephora Sans, while others would be falling back to CenturyGothic, Helvetica, Arial, respectively.

In order to solve the issue mentioned above, we are removing Sephora Sans and Sephora Serif as a font, only when the site is Vietnam, and language is Vietnamese so the fonts appear consistent throughout the site.

[related PR in luxola repo ](https://github.com/sephora-asia/luxola/pull/2696)

<img width="1153" alt="Screenshot 2021-12-03 at 3 21 34 PM" src="https://user-images.githubusercontent.com/25855250/144555573-7b200fbc-5ddf-4822-9746-e35e51816891.png">

