### PR TITLE
Reorder Vi custom font family

### DIFF
--- a/app/assets/stylesheets/sephora_style_guide/_reset.scss
+++ b/app/assets/stylesheets/sephora_style_guide/_reset.scss
@@ -29,8 +29,8 @@ html {
     line-height: $line-height-root;
   }
 
-  :lang(vi) { 
-    font-family: CenturyGothic, Helvetica, Arial; 
+  :lang(vi) {
+    font-family: Helvetica, CenturyGothic, Arial;
   }
 }
 

--- a/app/assets/stylesheets/sephora_style_guide/mixins/_typography.scss
+++ b/app/assets/stylesheets/sephora_style_guide/mixins/_typography.scss
@@ -26,8 +26,8 @@
   font-weight: 400;
   letter-spacing: 0.3px;
 
-  :lang(vi) { 
-    font-family: CenturyGothic, Helvetica, Arial; 
+  :lang(vi) {
+    font-family: Helvetica, CenturyGothic, Arial;
   }
 }
 


### PR DESCRIPTION
Re-ordering font family for Vi to reflect Helvetica, CenturyGothic, Arial; over Sephora Sans